### PR TITLE
Fix floating point exception in C extension and improve test coverage.

### DIFF
--- a/ctseval/create_benchmark_data.py
+++ b/ctseval/create_benchmark_data.py
@@ -34,11 +34,15 @@ if __name__ == '__main__':
     trajectory_df = pd.concat(trajectory_dfs)
     traj_list = convert_df_to_trajectory_list(trajectory_df, 'id', 'event_occurred', 'event_time', 'predicted_times', 'predicted_risks')
 
-    with open("../benchmark_data/benchmark_trajectories_200.json", "w") as f:
+    import os
+    # Create the benchmark_data directory if it doesn't exist
+    os.makedirs("benchmark_data", exist_ok=True)
+
+    with open("benchmark_data/benchmark_trajectories_200.json", "w") as f:
         json.dump(traj_list[0:200], f, indent=2)
 
-    with open("../benchmark_data/benchmark_trajectories_2000.json", "w") as f:
+    with open("benchmark_data/benchmark_trajectories_2000.json", "w") as f:
         json.dump(traj_list[0:2000], f, indent=2)
         
-    with open("../benchmark_data/benchmark_trajectories_20000.json", "w") as f:
+    with open("benchmark_data/benchmark_trajectories_20000.json", "w") as f:
         json.dump(traj_list, f, indent=2)

--- a/ctseval/ctseval.c
+++ b/ctseval/ctseval.c
@@ -403,7 +403,7 @@ int compute_metrics(PyObject *trajectories_obj, double snooze_window, double det
             }
 
             // Print progress and time estimation
-            if (t > 0 && t % print_interval == 0) {
+            if (print_interval > 0 && t > 0 && t % print_interval == 0) {
                 current = clock();
                 cpu_time_used = ((double) (current - start)) / CLOCKS_PER_SEC;
                 double progress = (double)(t + 1) / risk_scores_count;

--- a/tests/validations/test_function_inputs.py
+++ b/tests/validations/test_function_inputs.py
@@ -98,3 +98,30 @@ def test_validate_trajectories_schema_invalid_event_time():
     ]
     with pytest.raises(ValueError, match="The 'event_time' key must be a number"):
         ctseval.validate_trajectories_schema(invalid_trajectories)
+
+def test_compute_metrics_integer_predictions(benchmark_20):
+    # Modify a trajectory to have integer predictions
+    modified_trajectory = benchmark_20[0].copy()
+    modified_trajectory["predicted_times"] = [1, 2, 3]
+    modified_trajectory["predicted_risks"] = [0, 1, 0]
+
+    result = ctseval.compute_metrics([modified_trajectory], snooze_window=0, detection_window=12)
+    assert result is not None
+
+def test_compute_metrics_float_predictions(benchmark_20):
+    # Ensure a trajectory has float predictions (original benchmark data might already be float)
+    modified_trajectory = benchmark_20[0].copy()
+    modified_trajectory["predicted_times"] = [1.0, 2.0, 3.0]
+    modified_trajectory["predicted_risks"] = [0.0, 1.0, 0.0]
+
+    result = ctseval.compute_metrics([modified_trajectory], snooze_window=0, detection_window=12)
+    assert result is not None
+
+def test_compute_metrics_mixed_predictions(benchmark_20):
+    # Modify a trajectory to have mixed integer and float predictions
+    modified_trajectory = benchmark_20[0].copy()
+    modified_trajectory["predicted_times"] = [1, 2.0, 3]
+    modified_trajectory["predicted_risks"] = [0.0, 1, 0.0]
+
+    result = ctseval.compute_metrics([modified_trajectory], snooze_window=0, detection_window=12)
+    assert result is not None


### PR DESCRIPTION
- Fixed a division by zero error in the C extension that occurred when `snooze_window` was a small float and `risk_scores_count` was less than 10.
- Added tests to `tests/validations/test_function_inputs.py` to cover integer, float, and mixed data types in `predicted_times` and `predicted_risks`.
- Modified `ctseval/create_benchmark_data.py` to save benchmark files directly into the `benchmark_data` directory in the project root, resolving a `FileNotFoundError` in tests.